### PR TITLE
fixes issue where Makefile var WEB_CONSOLE_VERSION gets overwritten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,7 @@ ifeq ($(RELEASE),stable)
 	  echo "Cannot get web_console version from pyproject.toml"; \
 	  exit 1; \
 	fi
-endif
-ifeq ($(WEB_CONSOLE_VERSION),)
+else ifeq ($(WEB_CONSOLE_VERSION),)
 	$(eval WEB_CONSOLE_VERSION := $(shell npm view @inmanta/web-console --json |jq -r '."dist-tags".$(RELEASE)'))
 endif
 ifeq ($(RELEASE),next)


### PR DESCRIPTION
# Description

If I understand correctly GNU make interprets conditionals at load time. So at the moment `ifeq ($(WEB_CONSOLE_VERSION),)` is checked, `$(WEB_CONSOLE_VERSION)` hasn't been set yet. Therefore it's body is added to the recipe. When the recipe is executed, this line immediately overwrites the correct variable that has been set before. As a result the variable ends up being `null`.