### PR TITLE
specfile: constrain python3-inmanta to iso3 range

### DIFF
--- a/inmanta.spec
+++ b/inmanta.spec
@@ -29,11 +29,11 @@ Source1:        deps-%{sourceversion}.tar.gz
 Source2:        inmanta-web-console-%{web_console_version}.tgz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:  python3-inmanta >= 2020.4.0, python3-inmanta < 2020.5.0
+BuildRequires:  python3-inmanta < 2020.5.0
 BuildRequires:  systemd
 BuildRequires:  nodejs
 
-Requires:  python3-inmanta >= 2020.4.0, python3-inmanta < 2020.5.0
+Requires:  python3-inmanta < 2020.5.0
 
 # Use the correct python for bycompiling
 %define __python %{_p3}


### PR DESCRIPTION
The RPM build for iso3 failed. I believe the cause was that it depended on the newest `python3-inmanta`, which contains `inmanta 2020.7`. The RPM for this branch has been built [here](https://jenkins.inmanta.com/job/releases/job/rpm/job/inmanta-ui-rpm/job/iso3-specfile-constraints/2/console). I inspected the log file and the issue seems to be resolved.

I'll apply this fix on all other extension repos as well as the `inmanta-service-orchestrator` repo.