### PR TITLE
cleanup legacy irt config in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,3 @@ exclude = '''
   | dist
 )/
 '''
-
-[tool.irt]
-web_console = 'master'


### PR DESCRIPTION
I'll cherry-pick this to `iso4` and the next branches.