### PR TITLE
pin web-console version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,4 @@ exclude = '''
 '''
 
 [tool.irt]
-web_console = '1.3.1'
+web_console = '1.3.2'


### PR DESCRIPTION
I'm not 100% sure of this but I think this needs to be bumped. This PR bumps it to the current dev version.

I'm planning to cherry-pick this to `iso3-next`.