### PR TITLE
Pin pip dependency

### DIFF
--- a/changelogs/unreleased/pin-pip-dependency.yml
+++ b/changelogs/unreleased/pin-pip-dependency.yml
@@ -1,0 +1,3 @@
+description: Pin version of pip to 21.0.1 due to a bug in version 21.1
+change-type: patch
+destination-branches: [iso3]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ inmanta~=2020.4.0.dev
 
 # Dependencies of the code
 tornado==6.1
+
+# Pin due to bug: https://github.com/pypa/pip/issues/9878
+pip==21.0.1


### PR DESCRIPTION
# Description

Pin version of pip to 21.0.1 due to a bug in version 21.1

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
