### PR TITLE
fixed makefile push target for next branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ ifeq ($(RELEASE),next)
 	if [ -n "$$(git ls-files -m pyproject.toml)" ]; then \
 	  git add pyproject.toml; \
 	  git commit -m "Pin version web console to $(WEB_CONSOLE_VERSION_STABLE_RELEASE)"; \
-	  git push origin HEAD:next; \
+	  git push origin HEAD:iso3-next; \
 	fi
 endif
 

--- a/changelogs/unreleased/fix-makefile-push.yml
+++ b/changelogs/unreleased/fix-makefile-push.yml
@@ -1,0 +1,4 @@
+description: Fixed Makefile push target for next branch
+change-type: patch
+destination-branches:
+  - iso3


### PR DESCRIPTION
The makefile tries to push to the nonexistent `next` branch.