### PR TITLE
Fix redirect issue when running behind a proxy

### DIFF
--- a/changelogs/unreleased/203-proxy-redirect.yml
+++ b/changelogs/unreleased/203-proxy-redirect.yml
@@ -1,0 +1,4 @@
+description: Fix redirect issue when running behind a proxy
+issue-nr: 203
+change-type: patch
+destination-branches: [master, iso4]

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -71,7 +71,7 @@ class UISlice(ServerSlice):
             )
         )
         server._handlers.append(
-            routing.Rule(routing.PathMatches(r"%s" % location[:-1]), web.RedirectHandler, {"url": location})
+            routing.Rule(routing.PathMatches(r"%s" % location[:-1]), web.RedirectHandler, {"url": location[1:]})
         )
         server._handlers.append(
             routing.Rule(


### PR DESCRIPTION
# Description

By removing the leading slash, the redirect uses a relative-path reference instead of an absolute-path reference (https://www.rfc-editor.org/rfc/rfc3986#section-4.2), which resolves correctly even when running behind a reverse proxy

closes #203 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
