### PR TITLE
Constrain dependencies to an assumed compatible range (iso5)

### DIFF
--- a/changelogs/unreleased/version-constraints-assumed-compatible.yml
+++ b/changelogs/unreleased/version-constraints-assumed-compatible.yml
@@ -1,0 +1,5 @@
+description: Constrain dependencies to an assumed compatible range
+issue-nr: 1091
+issue-repo: irt
+change-type: patch
+destination-branches: [iso5]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 requires = [
     "inmanta-core~=6.0.dev",
-    "tornado",
+    "tornado~=6.0",
 ]
 
 namespace_packages = ["inmanta_ext.ui"]


### PR DESCRIPTION
related to inmanta/irt#1091

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] ~Type annotations are present~
- [x] Code is clear and sufficiently documented
- [x] ~No (preventable) type errors~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
