### PR TITLE
[FIX] Change regex maching rule for the flat file handler

### DIFF
--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -80,7 +80,7 @@ class UISlice(ServerSlice):
         options = {"path": path, "default_filename": "index.html"}
         server._handlers.append(
             routing.Rule(
-                routing.PathMatches(r"%s(.*\.[^\s]{2,5}$)" % location),
+                routing.PathMatches(r"%s(.*\.[\w]{2,5}$)" % location),
                 FlatFileHandler,
                 options,
             )

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -80,7 +80,7 @@ class UISlice(ServerSlice):
         options = {"path": path, "default_filename": "index.html"}
         server._handlers.append(
             routing.Rule(
-                routing.PathMatches(r"%s(.*\.[\w]{2,5}$)" % location),
+                routing.PathMatches(r"%s(.*\.\w{2,5}$)" % location),
                 FlatFileHandler,
                 options,
             )


### PR DESCRIPTION
# Description

An error 404 was raised for urls like
 `http://mgmt.ii.inmanta.com:8888/console/resources/exec%3A%3ARun[longevity-2022.1.ii.inmanta.com]`,
because the flat file handler pattern match was accepting all non-space characters as valid file extensions and therefore look for a file named `http://mgmt.ii.inmanta.com:8888/console/resources/exec%3A%3ARun[longevity-2022.1.ii.inmanta` with file extension `.com]`, which doesn't exist.

# Solution
Instead of disallowing spaces, only accept alphanumeric characters. 

closes #307 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
