### PR TITLE
issue/4780-add-timestamp-to-logs

### DIFF
--- a/changelogs/unreleased/4780-enable-timestamps-log-tests.yml
+++ b/changelogs/unreleased/4780-enable-timestamps-log-tests.yml
@@ -1,0 +1,5 @@
+description: Enable timestamp on the log messages produced by the test cases.
+issue-nr: 4780
+change-type: patch
+destination-branches: [master, iso5, iso4]
+issue-repo: inmanta-core

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,4 @@ public = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+log_format = "%(asctime)s.%(msecs)03d %(levelname)s %(message)s"


### PR DESCRIPTION
# Description

Enable timestamp on the log messages produced by the test cases

closes https://github.com/inmanta/inmanta-core/issues/4780
# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
