### PR TITLE
Fix: passenv in tox.ini file doesn't accept whitespaces (#350)

### DIFF
--- a/changelogs/unreleased/fix-tox-issue-passenv.yml
+++ b/changelogs/unreleased/fix-tox-issue-passenv.yml
@@ -1,0 +1,7 @@
+description: Fix issue with passenv in tox.ini file
+change-type: patch
+destination-branches:
+  - master
+  - iso6
+  - iso5
+  - iso4

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ pip_pre=true
 commands_pre=pip check
 commands=py.test --cov=inmanta_ext.inmanta_ui --cov=inmanta_ui --cov-report  term --cov-report xml --junitxml=junit-{envname}.xml -vvv tests/
 # The INMANTA_RETRY_LIMITED_MULTIPLIER is used to set a multiplier in the retry_limited function
-passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT INMANTA_RETRY_LIMITED_MULTIPLIER
+passenv=SSH_AUTH_SOCK,ASYNC_TEST_TIMEOUT,INMANTA_RETRY_LIMITED_MULTIPLIER
 basepython = python3.9
 
 [testenv:pep8]


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #350