### PR TITLE
Bump inmanta-dev-dependencies[async,extension,pytest] from 2.67.0 to 2.68.0 (#394)

### DIFF
--- a/changelogs/unreleased/394-dependabot.yml
+++ b/changelogs/unreleased/394-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: Bump inmanta-dev-dependencies[async,extension,pytest] from 2.67.0 to
+    2.68.0
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,4 +2,4 @@ bumpversion==0.6.0
 # Guide pip in finding appropriate versions by using the bound extra for pytest-inmanta-extensions.
 # This way inmanta-core and pytest-inmanta-extensions versions are bound, which should reduce backtracking on the latter.
 inmanta-core[pytest-inmanta-extensions]
-inmanta-dev-dependencies[pytest,async,extension]==2.67.0
+inmanta-dev-dependencies[pytest,async,extension]==2.68.0


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #394