### PR TITLE
Remove inmanta core pytest inmanta extensions

### DIFF
--- a/changelogs/unreleased/remove-pytest-inmanta-extensions.yml
+++ b/changelogs/unreleased/remove-pytest-inmanta-extensions.yml
@@ -1,0 +1,3 @@
+description: remove the inmanta-core[pytest-inmanta-extensions] requirement from requirements.dev.txt
+change-type: patch
+destination-branches: [master, iso6]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,2 @@
 bumpversion==0.6.0
-# Guide pip in finding appropriate versions by using the bound extra for pytest-inmanta-extensions.
-# This way inmanta-core and pytest-inmanta-extensions versions are bound, which should reduce backtracking on the latter.
-inmanta-core[pytest-inmanta-extensions]
 inmanta-dev-dependencies[pytest,async,extension]==2.94.0


### PR DESCRIPTION
# Description

remove the inmanta-core[pytest-inmanta-extensions] requirement from requirements.dev.txt.


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
