### PR TITLE
Auth method in config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Shortcuts for various dev tasks. Based on makefile from pydantic
 .DEFAULT_GOAL := all
-isort = isort -rc src tests
+isort = isort src tests
 black = black src tests
 
 GET_WEB_CONSOLE_VERSION_REGEX := \(\[tool.irt\][^\[]*web_console\s*=\s*[\"']\)\([^\"'\n]*\)\([\"']\)

--- a/changelogs/unreleased/auth-method.yml
+++ b/changelogs/unreleased/auth-method.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Add auth method to config.js
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -80,7 +80,7 @@ class UISlice(ServerSlice):
                     'clientId': '{oidc_client_id.get()}'
                 }};\n"""  # Use the same client-id as the dashboard
         else:
-            config_js_content = f"""
+            config_js_content = """
                 window.auth = {{
                     'method': 'database',
                 }};\n"""  # Use the same client-id as the dashboard

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -86,7 +86,9 @@ class UISlice(ServerSlice):
                         'method': 'database',
                     }};\n"""  # Use the same client-id as the dashboard
             else:
-                raise Exception(f"Invalid value for config option server.auth_method: {opt.server_auth_method.get()}. Expected either 'oidc' or 'database'.")
+                raise Exception(
+                    f"Invalid value for config option server.auth_method: {opt.server_auth_method.get()}. Expected either 'oidc' or 'database'."
+                )
 
         config_js_content += f"\nexport const features = {json.dumps(web_console_features.get())};\n"
 

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -71,13 +71,19 @@ class UISlice(ServerSlice):
         LOGGER.info("Serving the web-console from %s", path)
 
         config_js_content = ""
-        if opt.server_enable_auth.get():
+        if opt.server_enable_auth.get() and opt.server_auth_method.get() != "database":
             config_js_content = f"""
-        window.auth = {{
-            'realm': '{oidc_realm.get()}',
-            'url': '{oidc_auth_url.get()}',
-            'clientId': '{oidc_client_id.get()}'
-        }};\n"""  # Use the same client-id as the dashboard
+                window.auth = {{
+                    'method': 'oidc',
+                    'realm': '{oidc_realm.get()}',
+                    'url': '{oidc_auth_url.get()}',
+                    'clientId': '{oidc_client_id.get()}'
+                }};\n"""  # Use the same client-id as the dashboard
+        else:
+            config_js_content = f"""
+                window.auth = {{
+                    'method': 'database',
+                }};\n"""  # Use the same client-id as the dashboard
 
         config_js_content += f"\nexport const features = {json.dumps(web_console_features.get())};\n"
 

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -71,19 +71,20 @@ class UISlice(ServerSlice):
         LOGGER.info("Serving the web-console from %s", path)
 
         config_js_content = ""
-        if opt.server_enable_auth.get() and opt.server_auth_method.get() != "database":
-            config_js_content = f"""
-                window.auth = {{
-                    'method': 'oidc',
-                    'realm': '{oidc_realm.get()}',
-                    'url': '{oidc_auth_url.get()}',
-                    'clientId': '{oidc_client_id.get()}'
-                }};\n"""  # Use the same client-id as the dashboard
-        else:
-            config_js_content = """
-                window.auth = {{
-                    'method': 'database',
-                }};\n"""  # Use the same client-id as the dashboard
+        if opt.server_enable_auth.get():
+            if opt.server_auth_method.get() != "database":
+                config_js_content = f"""
+                    window.auth = {{
+                        'method': 'oidc',
+                        'realm': '{oidc_realm.get()}',
+                        'url': '{oidc_auth_url.get()}',
+                        'clientId': '{oidc_client_id.get()}'
+                    }};\n"""  # Use the same client-id as the dashboard
+            else:
+                config_js_content = """
+                    window.auth = {{
+                        'method': 'database',
+                    }};\n"""  # Use the same client-id as the dashboard
 
         config_js_content += f"\nexport const features = {json.dumps(web_console_features.get())};\n"
 

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -72,7 +72,7 @@ class UISlice(ServerSlice):
 
         config_js_content = ""
         if opt.server_enable_auth.get():
-            if opt.server_auth_method.get() != "database":
+            if opt.server_auth_method.get() == "oidc":
                 config_js_content = f"""
                     window.auth = {{
                         'method': 'oidc',
@@ -80,11 +80,13 @@ class UISlice(ServerSlice):
                         'url': '{oidc_auth_url.get()}',
                         'clientId': '{oidc_client_id.get()}'
                     }};\n"""  # Use the same client-id as the dashboard
-            else:
+            elif opt.server_auth_method.get() == "database":
                 config_js_content = """
                     window.auth = {{
                         'method': 'database',
                     }};\n"""  # Use the same client-id as the dashboard
+            else:
+                raise Exception(f"Invalid value for config option server.auth_method: {opt.server_auth_method.get()}. Expected either 'oidc' or 'database'.")
 
         config_js_content += f"\nexport const features = {json.dumps(web_console_features.get())};\n"
 

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -87,7 +87,8 @@ class UISlice(ServerSlice):
                     }};\n"""  # Use the same client-id as the dashboard
             else:
                 raise Exception(
-                    f"Invalid value for config option server.auth_method: {opt.server_auth_method.get()}. Expected either 'oidc' or 'database'."
+                    f"Invalid value for config option server.auth_method: {opt.server_auth_method.get()}. "
+                    "Expected either 'oidc' or 'database'."
                 )
 
         config_js_content += f"\nexport const features = {json.dumps(web_console_features.get())};\n"


### PR DESCRIPTION
# Description

Return the auth method in the config. I used a container with the two methods to verify that we create the correct config.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
