### PR TITLE
Use new default value for server.auth_method

### DIFF
--- a/changelogs/unreleased/use-new-def-value-server-auth-method.yml
+++ b/changelogs/unreleased/use-new-def-value-server-auth-method.yml
@@ -1,0 +1,4 @@
+---
+description: Use a newer version of inmanta-core that uses a new default value for the server.auth_method config option (oidc instead of None).
+change-type: patch
+destination-branches: [master, iso7]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 requires = [
-    "inmanta-core>=6.0.0.dev",
+    "inmanta-core>=11.1.0.dev",
     "tornado~=6.0",
 ]
 

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -72,7 +72,8 @@ class UISlice(ServerSlice):
 
         config_js_content = ""
         if opt.server_enable_auth.get():
-            if opt.server_auth_method.get() == "oidc":
+            server_auth_method: str = opt.server_auth_method.get()
+            if server_auth_method == "oidc":
                 config_js_content = f"""
                     window.auth = {{
                         'method': 'oidc',
@@ -80,7 +81,7 @@ class UISlice(ServerSlice):
                         'url': '{oidc_auth_url.get()}',
                         'clientId': '{oidc_client_id.get()}'
                     }};\n"""  # Use the same client-id as the dashboard
-            elif opt.server_auth_method.get() == "database":
+            elif server_auth_method == "database":
                 config_js_content = """
                     window.auth = {{
                         'method': 'database',

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -59,7 +59,8 @@ def inmanta_ui_config_with_auth_enabled(inmanta_ui_config):
 @pytest.mark.asyncio
 async def test_auth_enabled(inmanta_ui_config_with_auth_enabled, server):
     """
-    Ensure that the ui extension doesn't crash if auth is enabled and the auth_method is left to its default value.
+    Ensure that the ui extension doesn't crash if server.auth config option is enabled
+    and the server.auth_method is left to its default value.
     """
     base_url = f"http://127.0.0.1:{config.get_bind_port()}/console"
     client = AsyncHTTPClient()

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -51,6 +51,22 @@ async def test_web_console_handler(server, inmanta_ui_config):
     assert "Should be served by default" in response.body.decode("UTF-8")
 
 
+@pytest.fixture
+def inmanta_ui_config_with_auth_enabled(inmanta_ui_config):
+    config.Config.set("server", "auth", "True")
+
+
+@pytest.mark.asyncio
+async def test_auth_enabled(inmanta_ui_config_with_auth_enabled, server):
+    """
+    Ensure that the ui extension doesn't crash if auth is enabled and the auth_method is left to its default value.
+    """
+    base_url = f"http://127.0.0.1:{config.get_bind_port()}/console"
+    client = AsyncHTTPClient()
+    response = await client.fetch(base_url)
+    assert response.code == 200
+
+
 @pytest.mark.asyncio
 async def test_start_location_redirect(server, inmanta_ui_config):
     """


### PR DESCRIPTION
# Description

Use a newer version of inmanta-core that uses a new default value for the server.auth_method config option (oidc instead of None).

This PR is part of a bugfix for https://inmanta.slack.com/archives/C045Y42N49W/p1709125944031899.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [] ~~End user documentation is included or an issue is created for end-user documentation~~