### PR TITLE
Fix issue were double curly brackets are present in the config.js

### DIFF
--- a/changelogs/unreleased/fix-double-curly-brackets.yml
+++ b/changelogs/unreleased/fix-double-curly-brackets.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix issue where the config.js contains double curly bracket when auth method is set to 'database'"
+change-type: patch
+destination-branches: [master, iso7]

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -83,9 +83,9 @@ class UISlice(ServerSlice):
                     }};\n"""  # Use the same client-id as the dashboard
             elif server_auth_method == "database":
                 config_js_content = """
-                    window.auth = {{
+                    window.auth = {
                         'method': 'database',
-                    }};\n"""  # Use the same client-id as the dashboard
+                    };\n"""  # Use the same client-id as the dashboard
             else:
                 raise Exception(
                     f"Invalid value for config option server.auth_method: {opt.server_auth_method.get()}. "


### PR DESCRIPTION
# Description

Fix issue where the config.js contains double curly bracket when auth method is set to 'database'

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
