### PR TITLE
Bump inmanta-dev-dependencies[async,extension,pytest] from 2.135.0 to 2.136.0 (#616)

### DIFF
--- a/changelogs/unreleased/616-dependabot.yml
+++ b/changelogs/unreleased/616-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: Bump inmanta-dev-dependencies[async,extension,pytest] from 2.135.0 to
+    2.136.0
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,2 +1,2 @@
 bumpversion==0.6.0
-inmanta-dev-dependencies[pytest,async,extension]==2.135.0
+inmanta-dev-dependencies[pytest,async,extension]==2.136.0


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #616