### PR TITLE
test fix compatibility with core logging config

### DIFF
--- a/changelogs/unreleased/configure-logging-fix.yml
+++ b/changelogs/unreleased/configure-logging-fix.yml
@@ -1,0 +1,5 @@
+description: Fixed test case compatibility with core's changes to the logging config
+change-type: patch
+destination-branches:
+  - master
+  - iso7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ async def server(inmanta_ui_config, server_config):
     """
     Override standard inmanta server to allow more config to be injected
     """
-    ibl = InmantaBootloader()
+    ibl = InmantaBootloader(configure_logging=True)
     await ibl.start()
 
     yield ibl.restserver


### PR DESCRIPTION
# Description

inmanta/inmanta-core#8501 makes the logging config mandatory when starting the server. This PR ensures it is loaded by passing `configure_logging=True`, as the inmanta-core tests do.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
