### PR TITLE
Fix makefile with respect to the tests_common directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ TESTS := tests
 PYTEST_EXTRA_ARGS :=
 
 .DEFAULT_GOAL := all
-isort = isort src tests tests_common
-black = black src tests tests_common
+isort = isort src tests $(wildcard tests_common)
+black = black src tests $(wildcard tests_common)
 packages := $(notdir $(patsubst %.egg-info,,$(wildcard src/*)))
 mypy = MYPYPATH=stubs:src $(PYTHON) -m mypy --soft-error-limit=-1 --html-report mypy $(addprefix -p , $(packages))
 mypy_baseline = $(PYTHON) -m mypy_baseline

--- a/changelogs/unreleased/fix-makefile-tests-common-dir.yml
+++ b/changelogs/unreleased/fix-makefile-tests-common-dir.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix makefile with respect to the handling of the tests_common directory."
+change-type: patch
+destination-branches: [master, iso8, iso7]


### PR DESCRIPTION
# Description

Fix makefile with respect to the handling of the tests_common directory.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~