### PR TITLE
Don't cache requests for /console/version.json

### DIFF
--- a/changelogs/unreleased/dont-cache-version-json-file.yml
+++ b/changelogs/unreleased/dont-cache-version-json-file.yml
@@ -1,0 +1,6 @@
+---
+description: "Make sure that requests for `/console/version.json` are not cached by the browser."
+change-type: patch
+destination-branches: [master, iso8, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 from typing import cast
+import datetime
 
 from tornado import routing, web
 
@@ -109,9 +110,17 @@ class UISlice(ServerSlice):
 
         config_js_content += f"\nexport const features = {json.dumps(web_console_features.get())};\n"
 
-        server.add_static_content(r"/console/(.*)config.js", content=config_js_content)
         location = "/console/"
         options = {"path": path, "default_filename": "index.html"}
+        server._handlers.append(
+            routing.Rule(
+                # Don't cache requests for the version.json file in the browser, because it's used by the web-cosole
+                # to determine whether the version of the web-console cached in the browser is out of sync with
+                # the version hosted by the server.
+                routing.PathMatches(r"/console/(version\.json)"), FlatFileHandler, {**options, "cache_time": 1}
+            )
+        )
+        server.add_static_content(r"/console/(.*)config.js", content=config_js_content)
         server._handlers.append(
             routing.Rule(
                 routing.PathMatches(r"%s(.*\.\w{2,5}$)" % location),
@@ -138,8 +147,17 @@ class SingleFileHandler(web.StaticFileHandler):
         return web.StaticFileHandler.get_absolute_path(root, "")
 
 
+
 class FlatFileHandler(web.StaticFileHandler):
     """Always serves files from the root folder, useful when using a proxy"""
+
+    def initialize(self, path: str, default_filename: str | None = None, cache_time: int | None = None) -> None:
+        """
+        :param cache_time: Indicates how long (in seconds) the file should be cached by the browser.
+                           If None, the default behavior of the StaticFileHandler is used.
+        """
+        super().initialize(path=path, default_filename=default_filename)
+        self.cache_time = cache_time
 
     @classmethod
     def get_absolute_path(cls, root, path):
@@ -147,3 +165,10 @@ class FlatFileHandler(web.StaticFileHandler):
         if parts:
             return web.StaticFileHandler.get_absolute_path(root, parts[-1])
         return web.StaticFileHandler.get_absolute_path(root, "")
+
+    def get_cache_time(
+       self, path: str, modified: datetime.datetime | None, mime_type: str
+    ) -> int:
+        if self.cache_time is not None:
+            return self.cache_time
+        return super().get_cache_time(path, modified, mime_type)

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -16,11 +16,11 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import datetime
 import json
 import logging
 import os
 from typing import cast
-import datetime
 
 from tornado import routing, web
 
@@ -117,7 +117,9 @@ class UISlice(ServerSlice):
                 # Don't cache requests for the version.json file in the browser, because it's used by the web-cosole
                 # to determine whether the version of the web-console cached in the browser is out of sync with
                 # the version hosted by the server.
-                routing.PathMatches(r"/console/(version\.json)"), FlatFileHandler, {**options, "cache_time": 1}
+                routing.PathMatches(r"/console/(version\.json)"),
+                FlatFileHandler,
+                {**options, "cache_time": 1},
             )
         )
         server.add_static_content(r"/console/(.*)config.js", content=config_js_content)
@@ -147,7 +149,6 @@ class SingleFileHandler(web.StaticFileHandler):
         return web.StaticFileHandler.get_absolute_path(root, "")
 
 
-
 class FlatFileHandler(web.StaticFileHandler):
     """Always serves files from the root folder, useful when using a proxy"""
 
@@ -166,9 +167,7 @@ class FlatFileHandler(web.StaticFileHandler):
             return web.StaticFileHandler.get_absolute_path(root, parts[-1])
         return web.StaticFileHandler.get_absolute_path(root, "")
 
-    def get_cache_time(
-       self, path: str, modified: datetime.datetime | None, mime_type: str
-    ) -> int:
+    def get_cache_time(self, path: str, modified: datetime.datetime | None, mime_type: str) -> int:
         if self.cache_time is not None:
             return self.cache_time
         return super().get_cache_time(path, modified, mime_type)

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -17,6 +17,7 @@ Contact: code@inmanta.com
 """
 
 import os.path
+
 import pytest
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError, HTTPRequest
 
@@ -118,4 +119,3 @@ async def test_no_caching_on_version_json(server, inmanta_ui_config, web_console
     cache_control_headers = response.headers.get_list("Cache-Control")
     assert len(cache_control_headers) == 1
     assert cache_control_headers[0] == "max-age=1"
-


### PR DESCRIPTION
# Description

This bug caused the banner, that warns the user about a mismatch between the locally cached version of the web-console and the one hosted by the server, to work incorrectly.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
