### PR TITLE
Don't cache index.html and config.js in browser

### DIFF
--- a/changelogs/unreleased/dont-cache-index-html-config-js.yml
+++ b/changelogs/unreleased/dont-cache-index-html-config-js.yml
@@ -1,0 +1,6 @@
+---
+description: Make sure the index.html and config.js file is not cached by the browser. 
+change-type: patch
+destination-branches: [master, iso8, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 requires = [
-    "inmanta-core>=11.1.0.dev",
+    "inmanta-core>=16.0.0.dev",
     "tornado~=6.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 requires = [
-    "inmanta-core>=16.0.0.dev",
+    "inmanta-core>=11.1.0.dev",
     "tornado~=6.0",
 ]
 

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -16,7 +16,6 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-import datetime
 import json
 import logging
 import os
@@ -189,4 +188,3 @@ class FlatFileHandler(FileHandlerWithCacheControl):
         if parts:
             return web.StaticFileHandler.get_absolute_path(root, parts[-1])
         return web.StaticFileHandler.get_absolute_path(root, "")
-

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -114,15 +114,27 @@ class UISlice(ServerSlice):
         options = {"path": path, "default_filename": "index.html"}
         server._handlers.append(
             routing.Rule(
-                # Don't cache requests for the version.json file in the browser, because it's used by the web-cosole
+                # Don't cache requests for the version.json file in the browser, because it's used by the web-console
                 # to determine whether the version of the web-console cached in the browser is out of sync with
                 # the version hosted by the server.
                 routing.PathMatches(r"/console/(version\.json)"),
                 FlatFileHandler,
-                {**options, "cache_time": 1},
+                {**options, "set_no_cache_header": True},
             )
         )
-        server.add_static_content(r"/console/(.*)config.js", content=config_js_content)
+        server.add_static_content(r"/console/(.*)config.js", content=config_js_content, set_no_cache_header=True)
+        server._handlers.append(
+            routing.Rule(
+                routing.PathMatches(r"%s(.*index\.html$)" % location),
+                FlatFileHandler,
+                # Never cache the index.html page. Otherwise we might try to fetch a dependency
+                # from the server that no longer exists.
+                {**options, "set_no_cache_header": True},
+            )
+        )
+        # Match regular files, like *.js, *.json, *.css, etc.
+        # These files can be cached safely, as they are a dependency of the index.html file,
+        # which is not cached.
         server._handlers.append(
             routing.Rule(
                 routing.PathMatches(r"%s(.*\.\w{2,5}$)" % location),
@@ -133,15 +145,34 @@ class UISlice(ServerSlice):
         server._handlers.append(
             routing.Rule(routing.PathMatches(r"%s" % location[:-1]), web.RedirectHandler, {"url": location[1:]})
         )
+        # All other URLs are directed to the index.html page.
         server._handlers.append(
             routing.Rule(
-                routing.PathMatches(r"%s(.*)" % location), SingleFileHandler, {"path": os.path.join(path, "index.html")}
+                routing.PathMatches(r"%s(.*)" % location),
+                SingleFileHandler,
+                # Never cache the index.html page. Otherwise we might try to fetch a dependency
+                # from the server that no longer exists.
+                {"path": os.path.join(path, "index.html"), "set_no_cache_header": True},
             )
         )
         self._handlers.append((r"/", web.RedirectHandler, {"url": location[1:]}))
 
 
-class SingleFileHandler(web.StaticFileHandler):
+class FileHandlerWithCacheControl(web.StaticFileHandler):
+
+    def initialize(self, path: str, default_filename: str | None = None, set_no_cache_header: bool = False) -> None:
+        """
+        :param set_no_cache_header: True iff the "Cache-Control: no-cache" header will be set.
+        """
+        super().initialize(path=path, default_filename=default_filename)
+        self.set_no_cache_header = set_no_cache_header
+
+    def set_extra_headers(self, path: str) -> None:
+        if self.set_no_cache_header:
+            self.set_header("Cache-Control", "no-cache")
+
+
+class SingleFileHandler(FileHandlerWithCacheControl):
     """Always serves the single file given in the path option, useful for single page applications with client-side routing"""
 
     @classmethod
@@ -149,16 +180,8 @@ class SingleFileHandler(web.StaticFileHandler):
         return web.StaticFileHandler.get_absolute_path(root, "")
 
 
-class FlatFileHandler(web.StaticFileHandler):
+class FlatFileHandler(FileHandlerWithCacheControl):
     """Always serves files from the root folder, useful when using a proxy"""
-
-    def initialize(self, path: str, default_filename: str | None = None, cache_time: int | None = None) -> None:
-        """
-        :param cache_time: Indicates how long (in seconds) the file should be cached by the browser.
-                           If None, the default behavior of the StaticFileHandler is used.
-        """
-        super().initialize(path=path, default_filename=default_filename)
-        self.cache_time = cache_time
 
     @classmethod
     def get_absolute_path(cls, root, path):
@@ -167,7 +190,3 @@ class FlatFileHandler(web.StaticFileHandler):
             return web.StaticFileHandler.get_absolute_path(root, parts[-1])
         return web.StaticFileHandler.get_absolute_path(root, "")
 
-    def get_cache_time(self, path: str, modified: datetime.datetime | None, mime_type: str) -> int:
-        if self.cache_time is not None:
-            return self.cache_time
-        return super().get_cache_time(path, modified, mime_type)

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -115,13 +115,13 @@ async def test_caching(server, inmanta_ui_config, web_console_path: str):
         with open(path, "w") as fh:
             fh.write("test")
 
-    for (url_path, can_be_cached) in [
-        ("/", False),                                  # Serve index.html -> No caching
-        ("/console/", False),                          # Serve index.html -> No caching
-        ("/console/index.html", False),                # Serve index.html -> No caching
-        ("/console/something/else", False),            # Serve index.html -> No caching
-        ("/console/version.json", False),              # version.json is never cached
-        ("/console/config.js", False),                 # config.json is never cached
+    for url_path, can_be_cached in [
+        ("/", False),  # Serve index.html -> No caching
+        ("/console/", False),  # Serve index.html -> No caching
+        ("/console/index.html", False),  # Serve index.html -> No caching
+        ("/console/something/else", False),  # Serve index.html -> No caching
+        ("/console/version.json", False),  # version.json is never cached
+        ("/console/config.js", False),  # config.json is never cached
         ("/console/something/else/config.js", False),  # config.json is never cached.
         ("/console/something.css", True),
         ("/console/aaa/bbb/something.css", True),

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -103,19 +103,38 @@ async def test_web_console_config(server, inmanta_ui_config):
     assert '\nexport const features = ["A", "B", "C"];' in response.body.decode()
 
 
-async def test_no_caching_on_version_json(server, inmanta_ui_config, web_console_path: str):
+async def test_caching(server, inmanta_ui_config, web_console_path: str):
     """
-    Verify that requests for the version.json file set the response header that
-    stops the browser from caching the request.
+    Verify that requests for the version.json, config.js and index.html files
+    set the response header that stops the browser from caching the file. Other
+    files should not be cached.
     """
-    path_version_json = os.path.join(web_console_path, "version.json")
-    with open(path_version_json, "w") as fh:
-        fh.write("test")
+    # Ensure the required files exist in the root of the web-console folder.
+    for file in ["version.json", "config.js", "something.css", "something.js"]:
+        path = os.path.join(web_console_path, file)
+        with open(path, "w") as fh:
+            fh.write("test")
 
-    base_url = f"http://127.0.0.1:{config.server_bind_port.get()}/console/version.json"
-    client = AsyncHTTPClient()
-    response = await client.fetch(base_url)
-    assert response.code == 200
-    cache_control_headers = response.headers.get_list("Cache-Control")
-    assert len(cache_control_headers) == 1
-    assert cache_control_headers[0] == "max-age=1"
+    for (url_path, can_be_cached) in [
+        ("/", False),                                  # Serve index.html -> No caching
+        ("/console/", False),                          # Serve index.html -> No caching
+        ("/console/index.html", False),                # Serve index.html -> No caching
+        ("/console/something/else", False),            # Serve index.html -> No caching
+        ("/console/version.json", False),              # version.json is never cached
+        ("/console/config.js", False),                 # config.json is never cached
+        ("/console/something/else/config.js", False),  # config.json is never cached.
+        ("/console/something.css", True),
+        ("/console/aaa/bbb/something.css", True),
+        ("/console/something.js", True),
+        ("/console/aaa/bbb/something.js", True),
+    ]:
+        base_url = f"http://127.0.0.1:{config.server_bind_port.get()}{url_path}"
+        client = AsyncHTTPClient()
+        response = await client.fetch(base_url)
+        assert response.code == 200
+        cache_control_headers = response.headers.get_list("Cache-Control")
+        if can_be_cached:
+            assert not cache_control_headers
+        else:
+            assert len(cache_control_headers) == 1, f"No Cache-Control header found for {url_path}"
+            assert cache_control_headers[0] == "no-cache", f"Invalid value found for Cache-Control header for {url_path}"


### PR DESCRIPTION
# Description

Make sure the `index.html` and `config.js` files are not cached by the browser.

* Caching the `index.html` can cause the web-console to blank out at load time. This happens when:

    * The version on the web-console is updated on the server
    * The index.html page is loaded from the browser cache
    * A dependency of the index.html file (e.g., a javascript file) is fetched from the server, but the new version of the web-console on the server no longer has this file.

* The `config.js` must not be cached because it can cause the auth method used by the server and the web-console to become out of sync.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~