### PR TITLE
Always set no-cache response header on /console endpoint

### DIFF
--- a/changelogs/unreleased/disable-caching-console-endpoint.yml
+++ b/changelogs/unreleased/disable-caching-console-endpoint.yml
@@ -1,0 +1,4 @@
+---
+description: "Always set no-cache response header on requests to /console endpoint."
+change-type: patch
+destination-branches: [master, iso8, iso7]

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -71,6 +71,13 @@ class UISlice(ServerSlice):
         return [composer]
 
     def add_web_console_handler(self, server: Server) -> None:
+        """
+        All handlers created here must set the "Cache-Control: no-cache" header.
+            * This prevents caching issues in the browser.
+            * We keep the performance overhead of this limited by relying on the etag support
+              in the StaticFileHandler of Tornado, i.e. we don't transfer large files
+              over and over again if the content of that file hasn't changed.
+        """
         if not web_console_enabled.get():
             LOGGER.info("The web-console is disabled.")
             return
@@ -113,12 +120,9 @@ class UISlice(ServerSlice):
         options = {"path": path, "default_filename": "index.html"}
         server._handlers.append(
             routing.Rule(
-                # Don't cache requests for the version.json file in the browser, because it's used by the web-console
-                # to determine whether the version of the web-console cached in the browser is out of sync with
-                # the version hosted by the server.
                 routing.PathMatches(r"/console/(version\.json)"),
                 FlatFileHandler,
-                {**options, "set_no_cache_header": True},
+                options,
             )
         )
         server.add_static_content(r"/console/(.*)config.js", content=config_js_content, set_no_cache_header=True)
@@ -126,14 +130,10 @@ class UISlice(ServerSlice):
             routing.Rule(
                 routing.PathMatches(r"%s(.*index\.html$)" % location),
                 FlatFileHandler,
-                # Never cache the index.html page. Otherwise we might try to fetch a dependency
-                # from the server that no longer exists.
-                {**options, "set_no_cache_header": True},
+                options,
             )
         )
         # Match regular files, like *.js, *.json, *.css, etc.
-        # These files can be cached safely, as they are a dependency of the index.html file,
-        # which is not cached.
         server._handlers.append(
             routing.Rule(
                 routing.PathMatches(r"%s(.*\.\w{2,5}$)" % location),
@@ -149,9 +149,7 @@ class UISlice(ServerSlice):
             routing.Rule(
                 routing.PathMatches(r"%s(.*)" % location),
                 SingleFileHandler,
-                # Never cache the index.html page. Otherwise we might try to fetch a dependency
-                # from the server that no longer exists.
-                {"path": os.path.join(path, "index.html"), "set_no_cache_header": True},
+                {"path": os.path.join(path, "index.html")},
             )
         )
         self._handlers.append((r"/", web.RedirectHandler, {"url": location[1:]}))
@@ -159,7 +157,7 @@ class UISlice(ServerSlice):
 
 class FileHandlerWithCacheControl(web.StaticFileHandler):
 
-    def initialize(self, path: str, default_filename: str | None = None, set_no_cache_header: bool = False) -> None:
+    def initialize(self, path: str, default_filename: str | None = None, set_no_cache_header: bool = True) -> None:
         """
         :param set_no_cache_header: True iff the "Cache-Control: no-cache" header will be set.
         """

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -105,9 +105,8 @@ async def test_web_console_config(server, inmanta_ui_config):
 
 async def test_caching(server, inmanta_ui_config, web_console_path: str):
     """
-    Verify that requests for the version.json, config.js and index.html files
-    set the response header that stops the browser from caching the file. Other
-    files should not be cached.
+    Verify that requests for files like version.json, config.js and index.html
+    set the response header that stops the browser from caching the file.
     """
     # Ensure the required files exist in the root of the web-console folder.
     for file in ["version.json", "config.js", "something.css", "something.js"]:
@@ -115,26 +114,23 @@ async def test_caching(server, inmanta_ui_config, web_console_path: str):
         with open(path, "w") as fh:
             fh.write("test")
 
-    for url_path, can_be_cached in [
-        ("/", False),  # Serve index.html -> No caching
-        ("/console/", False),  # Serve index.html -> No caching
-        ("/console/index.html", False),  # Serve index.html -> No caching
-        ("/console/something/else", False),  # Serve index.html -> No caching
-        ("/console/version.json", False),  # version.json is never cached
-        ("/console/config.js", False),  # config.json is never cached
-        ("/console/something/else/config.js", False),  # config.json is never cached.
-        ("/console/something.css", True),
-        ("/console/aaa/bbb/something.css", True),
-        ("/console/something.js", True),
-        ("/console/aaa/bbb/something.js", True),
+    for url_path in [
+        "/",
+        "/console/",
+        "/console/index.html",
+        "/console/something/else",
+        "/console/version.json",
+        "/console/config.js",
+        "/console/something/else/config.js",
+        "/console/something.css",
+        "/console/aaa/bbb/something.css",
+        "/console/something.js",
+        "/console/aaa/bbb/something.js",
     ]:
         base_url = f"http://127.0.0.1:{config.server_bind_port.get()}{url_path}"
         client = AsyncHTTPClient()
         response = await client.fetch(base_url)
         assert response.code == 200
         cache_control_headers = response.headers.get_list("Cache-Control")
-        if can_be_cached:
-            assert not cache_control_headers
-        else:
-            assert len(cache_control_headers) == 1, f"No Cache-Control header found for {url_path}"
-            assert cache_control_headers[0] == "no-cache", f"Invalid value found for Cache-Control header for {url_path}"
+        assert len(cache_control_headers) == 1, f"No Cache-Control header found for {url_path}"
+        assert cache_control_headers[0] == "no-cache", f"Invalid value found for Cache-Control header for {url_path}"


### PR DESCRIPTION
# Description

This PR makes sure we always set the no-cache response header on requests to `/console`. This prevents caching issues in the browser. We rely on the etag support from the Tornado handler to keep the performance good when loading the application.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~