### PR TITLE
Set the Last-Modified header correctly

### DIFF
--- a/changelogs/unreleased/fix-value-last-modified-header.yml
+++ b/changelogs/unreleased/fix-value-last-modified-header.yml
@@ -1,0 +1,6 @@
+---
+description: "Make sure that the Last-Modified header is set correctly."
+change-type: patch
+destination-branches: [master, iso8, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -16,11 +16,11 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import datetime
 import json
 import logging
 import os
-from typing import cast, Optional
-import datetime
+from typing import Optional, cast
 
 from tornado import routing, web
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import datetime
 import asyncio
 import concurrent
 import logging
@@ -55,7 +56,31 @@ async def server(inmanta_ui_config, server_config):
 
 
 @pytest.fixture
-def web_console_path(tmpdir):
+def build_date() -> datetime.datetime:
+    """
+    The build date of the web-console for the tests.
+    """
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+@pytest.fixture
+def version_json(build_date: datetime.datetime) -> str:
+    """
+    The content of the version.json file in the root of the web-console directory.
+    """
+    build_date_str = build_date.strftime("%Y-%m-%dT%H:%M:%S.%f")
+    build_date_str =  f"{build_date_str[0:-3]}Z"
+    return """
+    {
+      "version_info": {
+        "buildDate": "%s"
+      }
+    }
+    """ % build_date_str
+
+
+@pytest.fixture
+def web_console_path(tmpdir, version_json: str):
     with open(os.path.join(tmpdir, "index.html"), "w") as index:
         index.write(
             """<!DOCTYPE html>
@@ -71,5 +96,7 @@ def web_console_path(tmpdir):
         )
     with open(os.path.join(tmpdir, "asset.js"), "w") as asset_file:
         asset_file.write("// Additional javascript file")
+    with open(os.path.join(tmpdir, "version.json"), "w") as fh:
+        fh.write(version_json)
 
     return tmpdir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,9 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-import datetime
 import asyncio
 import concurrent
+import datetime
 import logging
 import os
 
@@ -69,14 +69,17 @@ def version_json(build_date: datetime.datetime) -> str:
     The content of the version.json file in the root of the web-console directory.
     """
     build_date_str = build_date.strftime("%Y-%m-%dT%H:%M:%S.%f")
-    build_date_str =  f"{build_date_str[0:-3]}Z"
-    return """
+    build_date_str = f"{build_date_str[0:-3]}Z"
+    return (
+        """
     {
       "version_info": {
         "buildDate": "%s"
       }
     }
-    """ % build_date_str
+    """
+        % build_date_str
+    )
 
 
 @pytest.fixture

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -136,7 +136,7 @@ async def test_caching(server, inmanta_ui_config, web_console_path: str, build_d
         assert len(cache_control_headers) == 1, f"No Cache-Control header found for {url_path}"
         assert cache_control_headers[0] == "no-cache", f"Invalid value found for Cache-Control header for {url_path}"
         assert response.headers.get_list("Etag")
-        last_modified_header =  response.headers.get_list("Last-Modified")
+        last_modified_header = response.headers.get_list("Last-Modified")
         if url_path.endswith("/config.js"):
             # The config.js file is never cached
             assert len(last_modified_header) == 0

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import datetime
 import os.path
 
 import pytest
@@ -103,13 +104,13 @@ async def test_web_console_config(server, inmanta_ui_config):
     assert '\nexport const features = ["A", "B", "C"];' in response.body.decode()
 
 
-async def test_caching(server, inmanta_ui_config, web_console_path: str):
+async def test_caching(server, inmanta_ui_config, web_console_path: str, build_date: datetime.datetime):
     """
     Verify that requests for files like version.json, config.js and index.html
     set the response header that stops the browser from caching the file.
     """
     # Ensure the required files exist in the root of the web-console folder.
-    for file in ["version.json", "config.js", "something.css", "something.js"]:
+    for file in ["config.js", "something.css", "something.js"]:
         path = os.path.join(web_console_path, file)
         with open(path, "w") as fh:
             fh.write("test")
@@ -134,3 +135,15 @@ async def test_caching(server, inmanta_ui_config, web_console_path: str):
         cache_control_headers = response.headers.get_list("Cache-Control")
         assert len(cache_control_headers) == 1, f"No Cache-Control header found for {url_path}"
         assert cache_control_headers[0] == "no-cache", f"Invalid value found for Cache-Control header for {url_path}"
+        assert response.headers.get_list("Etag")
+        last_modified_header =  response.headers.get_list("Last-Modified")
+        if url_path.endswith("/config.js"):
+            # The config.js file is never cached
+            assert len(last_modified_header) == 0
+        else:
+            assert len(last_modified_header) == 1
+            actual_last_modified_timestamp = datetime.datetime.strptime(last_modified_header[0], "%a, %d %b %Y %H:%M:%S %Z")
+            actual_last_modified_timestamp = actual_last_modified_timestamp.replace(tzinfo=datetime.timezone.utc)
+            # The Last-Modified header has seconds precision.
+            expected_last_modified_timestamp = build_date.replace(microsecond=0)
+            assert actual_last_modified_timestamp == expected_last_modified_timestamp


### PR DESCRIPTION
# Description

I noticed that we have caching issues on the web-console. It seems this is caused by Cloudflare dropping the `etag` header under some circumstances. I assume that several reverse proxies could the same thing. In this situation, the browser falls back to the `Last-Modified` header to determine whether the browser cache is still fresh. In the previous implementation this value was always to set to some fixed timestamp in 1985, because it's the modification timestamp of the file on disk. This PR fixes that issue by making sure that the `Last-Modified` header is set to the build date, included in the `version.json` file.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~