### PR TITLE
Use modification timestamp file for last-modified header

### DIFF
--- a/changelogs/unreleased/use-modification-time-files.yml
+++ b/changelogs/unreleased/use-modification-time-files.yml
@@ -1,0 +1,4 @@
+---
+description: "Use the modification time of files on disk for the last-modified header."
+change-type: patch
+destination-branches: [master, iso8, iso7]

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -16,11 +16,10 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-import datetime
 import json
 import logging
 import os
-from typing import Optional, cast
+from typing import cast
 
 from tornado import routing, web
 
@@ -167,28 +166,10 @@ class FileHandlerWithCacheControl(web.StaticFileHandler):
         """
         super().initialize(path=path, default_filename=default_filename)
         self.set_no_cache_header = set_no_cache_header
-        self._build_time: datetime.datetime = self._get_build_time()
-
-    def _get_build_time(self) -> datetime.datetime:
-        """
-        Returns a datetime object that contains the build_time of the web-console,
-        defined in the version.json file.
-        """
-        path_version_json_file = os.path.join(web_console_path.get(), "version.json")
-        with open(path_version_json_file, "r") as fh:
-            version_json_dct = json.load(fh)
-        return datetime.datetime.fromisoformat(version_json_dct["version_info"]["buildDate"])
 
     def set_extra_headers(self, path: str) -> None:
         if self.set_no_cache_header:
             self.set_header("Cache-Control", "no-cache")
-
-    def get_modified_time(self) -> Optional[datetime.datetime]:
-        """
-        We rely on the build time here, because the modification timestamps of the files
-        on disk are not guaranteed to be correct.
-        """
-        return self._build_time
 
 
 class SingleFileHandler(FileHandlerWithCacheControl):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@ Contact: code@inmanta.com
 
 import asyncio
 import concurrent
-import datetime
 import logging
 import os
 
@@ -56,34 +55,7 @@ async def server(inmanta_ui_config, server_config):
 
 
 @pytest.fixture
-def build_date() -> datetime.datetime:
-    """
-    The build date of the web-console for the tests.
-    """
-    return datetime.datetime.now(datetime.timezone.utc)
-
-
-@pytest.fixture
-def version_json(build_date: datetime.datetime) -> str:
-    """
-    The content of the version.json file in the root of the web-console directory.
-    """
-    build_date_str = build_date.strftime("%Y-%m-%dT%H:%M:%S.%f")
-    build_date_str = f"{build_date_str[0:-3]}Z"
-    return (
-        """
-    {
-      "version_info": {
-        "buildDate": "%s"
-      }
-    }
-    """
-        % build_date_str
-    )
-
-
-@pytest.fixture
-def web_console_path(tmpdir, version_json: str):
+def web_console_path(tmpdir):
     with open(os.path.join(tmpdir, "index.html"), "w") as index:
         index.write(
             """<!DOCTYPE html>
@@ -99,7 +71,5 @@ def web_console_path(tmpdir, version_json: str):
         )
     with open(os.path.join(tmpdir, "asset.js"), "w") as asset_file:
         asset_file.write("// Additional javascript file")
-    with open(os.path.join(tmpdir, "version.json"), "w") as fh:
-        fh.write(version_json)
 
     return tmpdir

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -17,6 +17,7 @@ Contact: code@inmanta.com
 """
 
 import datetime
+import os
 import os.path
 
 import pytest
@@ -104,16 +105,28 @@ async def test_web_console_config(server, inmanta_ui_config):
     assert '\nexport const features = ["A", "B", "C"];' in response.body.decode()
 
 
-async def test_caching(server, inmanta_ui_config, web_console_path: str, build_date: datetime.datetime):
+async def test_caching(server, inmanta_ui_config, web_console_path: str):
     """
     Verify that requests for files like version.json, config.js and index.html
     set the response header that stops the browser from caching the file.
     """
+
     # Ensure the required files exist in the root of the web-console folder.
-    for file in ["config.js", "something.css", "something.js"]:
+    for file in ["version.json", "config.js", "something.css", "something.js"]:
         path = os.path.join(web_console_path, file)
         with open(path, "w") as fh:
             fh.write("test")
+
+    # The modification timestamps are used by Tornado to determine the values
+    # for the last-modified header.
+    modification_timestamp = datetime.datetime.now().replace(microsecond=0).astimezone()
+    access_timestamp = modification_timestamp + datetime.timedelta(hours=5)
+    for root, dirs, files in os.walk(web_console_path):
+        for file in files:
+            os.utime(
+                path=os.path.join(root, file),
+                times=(access_timestamp.timestamp(), modification_timestamp.timestamp()),
+            )
 
     for url_path in [
         "/",
@@ -145,5 +158,4 @@ async def test_caching(server, inmanta_ui_config, web_console_path: str, build_d
             actual_last_modified_timestamp = datetime.datetime.strptime(last_modified_header[0], "%a, %d %b %Y %H:%M:%S %Z")
             actual_last_modified_timestamp = actual_last_modified_timestamp.replace(tzinfo=datetime.timezone.utc)
             # The Last-Modified header has seconds precision.
-            expected_last_modified_timestamp = build_date.replace(microsecond=0)
-            assert actual_last_modified_timestamp == expected_last_modified_timestamp
+            assert actual_last_modified_timestamp == modification_timestamp

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -118,7 +118,7 @@ async def test_caching(server, inmanta_ui_config, web_console_path: str):
             fh.write("test")
 
     # The modification timestamps are used by Tornado to determine the values
-    # for the last-modified header.
+    # for the last-modified header. The last-modified header has seconds precision.
     modification_timestamp = datetime.datetime.now().replace(microsecond=0).astimezone()
     access_timestamp = modification_timestamp + datetime.timedelta(hours=5)
     for root, dirs, files in os.walk(web_console_path):
@@ -157,5 +157,4 @@ async def test_caching(server, inmanta_ui_config, web_console_path: str):
             assert len(last_modified_header) == 1
             actual_last_modified_timestamp = datetime.datetime.strptime(last_modified_header[0], "%a, %d %b %Y %H:%M:%S %Z")
             actual_last_modified_timestamp = actual_last_modified_timestamp.replace(tzinfo=datetime.timezone.utc)
-            # The Last-Modified header has seconds precision.
             assert actual_last_modified_timestamp == modification_timestamp


### PR DESCRIPTION
# Description

Make sure that the modification timestamp of the file on disk is used in the last-modified header.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
