### PR TITLE
move internal dev constraints from setup.py to requirements.txt

### DIFF
--- a/changelogs/unreleased/1999-move-internal-dev-constraints-to-requirement-txt-iso8.yml
+++ b/changelogs/unreleased/1999-move-internal-dev-constraints-to-requirement-txt-iso8.yml
@@ -1,0 +1,5 @@
+description: Move internal dev constraints from setup.py to requirements.txt.
+issue-nr: 1999
+issue-repo: inmanta-lsm
+change-type: patch
+destination-branches: [iso8, iso7]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ inmanta-support>=0.dev
 inmanta-license>=0.dev
 inmanta-lsm>=0.dev
 inmanta-ui>=0.dev
+inmanta-core>=0.dev

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 requires = [
-    "inmanta-core>=11.1.0.dev",
+    "inmanta-core>=11.1.0",
     "tornado~=6.0",
 ]
 


### PR DESCRIPTION
# Description

part of https://github.com/inmanta/inmanta-lsm/issues/1999

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
