### PR TITLE
Added support for generic OIDC config generation

### DIFF
--- a/changelogs/unreleased/add-generic-oidc-support.yml
+++ b/changelogs/unreleased/add-generic-oidc-support.yml
@@ -1,0 +1,5 @@
+description: Added support for generic OIDC config generation, enabling identity providers like MS Entra ID, Okta, and Auth0 via the new oidc_authority config option.
+change-type: minor
+destination-branches: [master]
+sections:
+  feature: "{{description}}"

--- a/changelogs/unreleased/add-generic-oidc-support.yml
+++ b/changelogs/unreleased/add-generic-oidc-support.yml
@@ -1,5 +1,5 @@
 description: Added support for generic OIDC config generation, enabling identity providers like MS Entra ID, Okta, and Auth0 via the new oidc_authority config option.
 change-type: minor
-destination-branches: [master]
+destination-branches: [master, iso9]
 sections:
   feature: "{{description}}"

--- a/src/inmanta_ui/config.py
+++ b/src/inmanta_ui/config.py
@@ -53,18 +53,18 @@ oidc_client_id = Option(
 # When oidc_authority is set, the frontend uses oidc-client-ts with
 # authorization code flow + PKCE instead of keycloak-js implicit flow.
 # This works with any OIDC-compliant IdP (MS Entra ID, Okta, Auth0, etc.).
-oidc_authority: Option[str] = Option(
+oidc_authority = Option(
     "web-ui",
     "oidc_authority",
-    None,
+    "",
     "The OIDC authority URL (e.g. https://login.microsoftonline.com/{tenant-id}/v2.0). "
     "When set, the web console uses the generic OIDC provider instead of Keycloak.",
     is_str,
 )
-oidc_scope: Option[str] = Option(
+oidc_scope = Option(
     "web-ui",
     "oidc_scope",
-    None,
+    "",
     "Optional OIDC scopes override for the generic OIDC provider (default: 'openid profile email').",
     is_str,
 )

--- a/src/inmanta_ui/config.py
+++ b/src/inmanta_ui/config.py
@@ -40,14 +40,15 @@ web_console_features = Option(
 # OpenID Connect authentication
 ################################
 
+oidc_client_id = Option(
+    "web-ui", "oidc_client_id", None, "The OpenID Connect client id configured for this application.", is_str
+)
+
 # Legacy Keycloak-specific options (method: "oidc").
 # Used when oidc_authority is not set. The frontend receives these as a
 # keycloak-js config and uses the implicit flow.
 oidc_realm = Option("web-ui", "oidc_realm", "inmanta", "The realm to use for OpenID Connect authentication.", is_str)
 oidc_auth_url = Option("web-ui", "oidc_auth_url", None, "The auth url of the OpenID Connect server to use.", is_str)
-oidc_client_id = Option(
-    "web-ui", "oidc_client_id", None, "The OpenID Connect client id configured for this application.", is_str
-)
 
 # Generic OIDC options (method: "oidc-generic").
 # When oidc_authority is set, the frontend uses oidc-client-ts with

--- a/src/inmanta_ui/config.py
+++ b/src/inmanta_ui/config.py
@@ -53,7 +53,7 @@ oidc_client_id = Option(
 # When oidc_authority is set, the frontend uses oidc-client-ts with
 # authorization code flow + PKCE instead of keycloak-js implicit flow.
 # This works with any OIDC-compliant IdP (MS Entra ID, Okta, Auth0, etc.).
-oidc_authority = Option(
+oidc_authority: Option[str] = Option(
     "web-ui",
     "oidc_authority",
     None,
@@ -61,7 +61,7 @@ oidc_authority = Option(
     "When set, the web console uses the generic OIDC provider instead of Keycloak.",
     is_str,
 )
-oidc_scope = Option(
+oidc_scope: Option[str] = Option(
     "web-ui",
     "oidc_scope",
     None,

--- a/src/inmanta_ui/config.py
+++ b/src/inmanta_ui/config.py
@@ -65,7 +65,7 @@ oidc_authority = Option(
 oidc_scope = Option(
     "web-ui",
     "oidc_scope",
-    "",
-    "Optional OIDC scopes override for the generic OIDC provider (default: 'openid profile email').",
+    "openid profile email",
+    "Optional OIDC scopes override for the generic OIDC provider",
     is_str,
 )

--- a/src/inmanta_ui/config.py
+++ b/src/inmanta_ui/config.py
@@ -40,8 +40,31 @@ web_console_features = Option(
 # OpenID Connect authentication
 ################################
 
+# Legacy Keycloak-specific options (method: "oidc").
+# Used when oidc_authority is not set. The frontend receives these as a
+# keycloak-js config and uses the implicit flow.
 oidc_realm = Option("web-ui", "oidc_realm", "inmanta", "The realm to use for OpenID Connect authentication.", is_str)
 oidc_auth_url = Option("web-ui", "oidc_auth_url", None, "The auth url of the OpenID Connect server to use.", is_str)
 oidc_client_id = Option(
     "web-ui", "oidc_client_id", None, "The OpenID Connect client id configured for this application.", is_str
+)
+
+# Generic OIDC options (method: "oidc-generic").
+# When oidc_authority is set, the frontend uses oidc-client-ts with
+# authorization code flow + PKCE instead of keycloak-js implicit flow.
+# This works with any OIDC-compliant IdP (MS Entra ID, Okta, Auth0, etc.).
+oidc_authority = Option(
+    "web-ui",
+    "oidc_authority",
+    None,
+    "The OIDC authority URL (e.g. https://login.microsoftonline.com/{tenant-id}/v2.0). "
+    "When set, the web console uses the generic OIDC provider instead of Keycloak.",
+    is_str,
+)
+oidc_scope = Option(
+    "web-ui",
+    "oidc_scope",
+    None,
+    "Optional OIDC scopes override for the generic OIDC provider (default: 'openid profile email').",
+    is_str,
 )

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -102,7 +102,7 @@ class UISlice(ServerSlice):
             server_auth_method: str = opt.server_auth_method.get()
             if server_auth_method == "oidc":
                 authority = oidc_authority.get()
-                if authority is not None and authority != "None":
+                if authority:
                     # Generic OIDC mode: uses oidc-client-ts with authorization
                     # code flow + PKCE. Works with any OIDC-compliant IdP.
                     auth_config: dict[str, str] = {
@@ -112,7 +112,7 @@ class UISlice(ServerSlice):
                         "provider": opt.authorization_provider.get(),
                     }
                     scope = oidc_scope.get()
-                    if scope is not None and scope != "None":
+                    if scope:
                         auth_config["scope"] = scope
                     config_js_content = f"\nwindow.auth = {json.dumps(auth_config)};\n"
                 else:

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -31,7 +31,16 @@ from inmanta.server.protocol import ServerSlice
 from inmanta.server.server import Server
 from inmanta_ui.const import SLICE_UI
 
-from .config import oidc_auth_url, oidc_client_id, oidc_realm, web_console_enabled, web_console_features, web_console_path
+from .config import (
+    oidc_auth_url,
+    oidc_authority,
+    oidc_client_id,
+    oidc_realm,
+    oidc_scope,
+    web_console_enabled,
+    web_console_features,
+    web_console_path,
+)
 
 composer = extensions.BoolFeature(
     slice=SLICE_UI,
@@ -92,7 +101,23 @@ class UISlice(ServerSlice):
         if opt.server_enable_auth.get():
             server_auth_method: str = opt.server_auth_method.get()
             if server_auth_method == "oidc":
-                config_js_content = f"""
+                authority = oidc_authority.get()
+                if authority:
+                    # Generic OIDC mode: uses oidc-client-ts with authorization
+                    # code flow + PKCE. Works with any OIDC-compliant IdP.
+                    auth_config: dict[str, str] = {
+                        "method": "oidc-generic",
+                        "authority": authority,
+                        "clientId": oidc_client_id.get(),
+                        "provider": opt.authorization_provider.get(),
+                    }
+                    scope = oidc_scope.get()
+                    if scope:
+                        auth_config["scope"] = scope
+                    config_js_content = f"\nwindow.auth = {json.dumps(auth_config)};\n"
+                else:
+                    # Legacy Keycloak mode: uses keycloak-js with implicit flow.
+                    config_js_content = f"""
                     window.auth = {{
                         'method': 'oidc',
                         'realm': '{oidc_realm.get()}',

--- a/src/inmanta_ui/ui.py
+++ b/src/inmanta_ui/ui.py
@@ -102,7 +102,7 @@ class UISlice(ServerSlice):
             server_auth_method: str = opt.server_auth_method.get()
             if server_auth_method == "oidc":
                 authority = oidc_authority.get()
-                if authority:
+                if authority is not None and authority != "None":
                     # Generic OIDC mode: uses oidc-client-ts with authorization
                     # code flow + PKCE. Works with any OIDC-compliant IdP.
                     auth_config: dict[str, str] = {
@@ -112,7 +112,7 @@ class UISlice(ServerSlice):
                         "provider": opt.authorization_provider.get(),
                     }
                     scope = oidc_scope.get()
-                    if scope:
+                    if scope is not None and scope != "None":
                         auth_config["scope"] = scope
                     config_js_content = f"\nwindow.auth = {json.dumps(auth_config)};\n"
                 else:

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -16,7 +16,12 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import asyncio
+import concurrent
+import contextlib
 import datetime
+import json
+import logging
 import os
 import os.path
 
@@ -24,6 +29,9 @@ import pytest
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError, HTTPRequest
 
 from inmanta.server import config
+from inmanta.server.bootloader import InmantaBootloader
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
@@ -184,3 +192,96 @@ async def test_config_js(server, inmanta_ui_config, web_console_path: str):
     ]:
         response = await client.fetch(url, raise_error=False)
         assert response.code == response_code, url
+
+
+@contextlib.asynccontextmanager
+async def _start_server():
+    ibl = InmantaBootloader(configure_logging=True)
+    await ibl.start()
+    try:
+        yield ibl.restserver
+    finally:
+        try:
+            await asyncio.wait_for(ibl.stop(), 15)
+        except concurrent.futures.TimeoutError:
+            logger.exception("Timeout during stop of the server in teardown")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "oidc_config,expected_assertions",
+    [
+        pytest.param(
+            {
+                "web-ui.oidc_authority": "https://login.microsoftonline.com/test-tenant/v2.0",
+                "web-ui.oidc_client_id": "test-client-id",
+            },
+            {
+                "method": "oidc-generic",
+                "authority": "https://login.microsoftonline.com/test-tenant/v2.0",
+                "clientId": "test-client-id",
+                "!scope": True,
+            },
+            id="generic-without-scope",
+        ),
+        pytest.param(
+            {
+                "web-ui.oidc_authority": "https://login.microsoftonline.com/test-tenant/v2.0",
+                "web-ui.oidc_client_id": "test-client-id",
+                "web-ui.oidc_scope": "openid profile email api://inmantaso/.default",
+            },
+            {
+                "method": "oidc-generic",
+                "authority": "https://login.microsoftonline.com/test-tenant/v2.0",
+                "clientId": "test-client-id",
+                "scope": "openid profile email api://inmantaso/.default",
+            },
+            id="generic-with-scope",
+        ),
+        pytest.param(
+            {
+                "web-ui.oidc_realm": "test-realm",
+                "web-ui.oidc_auth_url": "https://keycloak.example.com/auth",
+                "web-ui.oidc_client_id": "test-client-id",
+            },
+            {
+                "method": "oidc",
+                "realm": "test-realm",
+                "url": "https://keycloak.example.com/auth",
+                "clientId": "test-client-id",
+            },
+            id="keycloak-legacy",
+        ),
+    ],
+)
+async def test_oidc_config(inmanta_ui_config, oidc_config, expected_assertions, server_config):
+    """
+    Verify that config.js emits the correct auth config for both the generic
+    OIDC provider (oidc_authority set) and the legacy Keycloak provider
+    (oidc_authority not set).
+    """
+    config.Config.set("server", "auth", "True")
+    config.Config.set("server", "auth_method", "oidc")
+    for key, value in oidc_config.items():
+        section, option = key.split(".", 1)
+        config.Config.set(section, option, value)
+
+    async with _start_server():
+        base_url = f"http://127.0.0.1:{config.server_bind_port.get()}/console/config.js"
+        client = AsyncHTTPClient()
+        response = await client.fetch(base_url)
+        assert response.code == 200
+
+        body = response.body.decode()
+
+        if expected_assertions["method"] == "oidc-generic":
+            auth_json = body.split("window.auth = ")[1].split(";\n")[0]
+            auth_config = json.loads(auth_json)
+            for key, value in expected_assertions.items():
+                if key.startswith("!"):
+                    assert key[1:] not in auth_config
+                else:
+                    assert auth_config[key] == value
+        else:
+            for key, value in expected_assertions.items():
+                assert f"'{key}': '{value}'" in body

--- a/tests/web_console_handler_test.py
+++ b/tests/web_console_handler_test.py
@@ -220,9 +220,9 @@ async def _start_server():
                 "method": "oidc-generic",
                 "authority": "https://login.microsoftonline.com/test-tenant/v2.0",
                 "clientId": "test-client-id",
-                "!scope": True,
+                "scope": "openid profile email",
             },
-            id="generic-without-scope",
+            id="generic-default-scope",
         ),
         pytest.param(
             {
@@ -278,10 +278,7 @@ async def test_oidc_config(inmanta_ui_config, oidc_config, expected_assertions, 
             auth_json = body.split("window.auth = ")[1].split(";\n")[0]
             auth_config = json.loads(auth_json)
             for key, value in expected_assertions.items():
-                if key.startswith("!"):
-                    assert key[1:] not in auth_config
-                else:
-                    assert auth_config[key] == value
+                assert auth_config[key] == value
         else:
             for key, value in expected_assertions.items():
                 assert f"'{key}': '{value}'" in body


### PR DESCRIPTION
enabling identity providers like MS Entra ID, Okta, and Auth0. When the new oidc_authority config option is set, the web console receives an "oidc-generic" config that uses authorization code flow with PKCE. Existing Keycloak deployments (without oidc_authority) continue to work unchanged with implicit flow.

# Description

* Short description here *

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
