### PR TITLE
Allow uv prereleases per package instead of globally (#826)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ mypy_baseline = $(PYTHON) -m mypy_baseline
 ifdef PIP_INDEX
 pip_index_arg := -i $(PIP_INDEX)
 endif
-uv_args = pip install --python $(PYTHON) --prerelease if-necessary-or-explicit $(pip_index_arg)
+uv_args = pip install --python $(PYTHON) $(pip_index_arg)
 ifeq ($(shell which uv),)
 bootstrap_pip_install = $(PYTHON) -m pip install $(pip_index_arg)
 else

--- a/changelogs/unreleased/uv-prerelease-per-package.yml
+++ b/changelogs/unreleased/uv-prerelease-per-package.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: Allow prereleases per package via the tool.uv section in pyproject.toml instead of passing --prerelease to uv
+destination-branches:
+- master
+- iso9
+- iso8
+sections: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,7 @@ public = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 log_format = "%(asctime)s.%(msecs)03d %(levelname)s %(message)s"
+
+[tool.uv]
+required-version = ">=0.12.1"
+prerelease-package = { inmanta-core = "allow", inmanta-license = "allow", inmanta-lsm = "allow", inmanta-support = "allow", pytest-inmanta-extensions = "allow" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bumpversion==0.6.0
 inmanta-dev-dependencies==2.187.0
 tornado==6.5.4
 
-# allow dev versions for extensions
+# allow dev versions for extensions (pip only, for uv use the `tool.uv` section in pyproject.toml)
 inmanta-support>=0.dev
 inmanta-license>=0.dev
 inmanta-lsm>=0.dev


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #826